### PR TITLE
Allow ONLINE/INFO ioctls while device is offline

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -198,7 +198,9 @@ long char_ctrl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 
 	xdma_debug_assert_msg(_IOC_TYPE(cmd) == XDMA_IOC_MAGIC, "bad magic.\n", -ENOTTY);
 
-	if(xdma_device_test_offline(xdev))
+	/* When offline, reject ioctls that touch the BARs. XDMA_IOCONLINE (to go
+	 * back online) and XDMA_IOCINFO (version read) are always allowed. */
+	if(xdma_device_test_offline(xdev) && cmd != XDMA_IOCONLINE && cmd != XDMA_IOCINFO)
 		return -EBUSY;
 
 	if (access_assert((void __user *)arg, _IOC_SIZE(cmd))<0)


### PR DESCRIPTION
XDMA_IOCOFFLINE was a one-way trip: every ioctl was rejected with -EBUSY while offline, including XDMA_IOCONLINE (the only way back) and the harmless XDMA_IOCINFO. Let both through so offline is recoverable without a module reload.