### PR TITLE
Wait for engine to go idle after clearing the Run bit

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -27,6 +27,7 @@
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/vmalloc.h>
+#include <linux/delay.h>
 
 #include "libxdma.h"
 #include "xdma_cdev.h"
@@ -436,6 +437,7 @@ static bool engine_process_status(struct xdma_engine *engine, u32 status)
 static int xdma_engine_stop(struct xdma_engine *engine)
 {
 	u32 w=0x1;
+	unsigned int retries = XDMA_ENGINE_STOP_TIMEOUT_US;
 
 	xdma_debug_assert_ptr(engine);
 	/* make no sense to write all the flags again. Just clear the Run bit*/
@@ -445,7 +447,23 @@ static int xdma_engine_stop(struct xdma_engine *engine)
 	write_register(w, &engine->regs->control_w1c,
 			(unsigned long)(&engine->regs->control_w1c) -
 				(unsigned long)(&engine->regs));
-	/* dummy read of status register to flush all previous writes */
+	/*
+	 * PG195 (Channel Control 0x04, Run bit): "if the engine is busy it
+	 * completes the current descriptor". Wait for Status.Busy to deassert
+	 * before the caller releases descriptor and data buffer memory,
+	 * otherwise the engine may still fetch descriptors or move data
+	 * into/from memory that is about to be freed and unmapped. Reading
+	 * the status register also flushes the posted Run-bit W1C write.
+	 */
+	while ((read_register(&engine->regs->status) & XDMA_STAT_BUSY)
+		&& (retries > 0)) {
+		udelay(1);
+		--retries;
+	}
+	if (unlikely(retries == 0))
+		pr_warn("Engine %s still busy %u us after clearing the Run bit\n",
+			engine->name, XDMA_ENGINE_STOP_TIMEOUT_US);
+
 	dbg_tfr("%s(%s) done\n", __func__, engine->name);
 	engine->running = 0;
 	return 0;

--- a/XDMA/linux-kernel/xdma/libxdma.h
+++ b/XDMA/linux-kernel/xdma/libxdma.h
@@ -64,6 +64,9 @@
 
 
 #define XDMA_MAX_C2H_CREDITS  ((1<<10)-1)
+
+/* how long to wait for Status.Busy to deassert after clearing the Run bit */
+#define XDMA_ENGINE_STOP_TIMEOUT_US	10000U
 /* bits of the SG DMA control register */
 #define XDMA_CTRL_RUN_STOP			(1U << 0)
 #define XDMA_CTRL_IE_DESC_STOPPED		(1U << 1)


### PR DESCRIPTION
Per PG195 (Channel Control 0x04, Run bit) a busy engine still completes its current descriptor after Run is cleared. xdma_engine_stop() returned immediately, so on the timeout/signal paths xdma_cleanup_transfer() could free descriptor blocks and unmap/unpin the data buffer while the engine was still using them - a DMA use-after-free. The claimed 'dummy read of status register' was not backed by any code either, so even the posted W1C write was never flushed.

Poll Status.Busy (bounded, 10 ms) after clearing Run; the read also flushes the posted write.