### PR TITLE
Clamp adjacent descriptor block length to the 64-descriptor limit

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1562,7 +1562,11 @@ static int engine_init(struct xdma_dev *xdev, enum dma_data_direction dir, int c
 		engine->streaming ? "ST" : "MM");
 	
 	    	
-	const_cast(unsigned int, engine->adj_block_len)=engine->xdev->max_read_request_size /sizeof(struct xdma_desc);
+	/* size adjacent blocks to the MRRS, but never above the 64-descriptor
+	   limit of the 6-bit Nxt_adj/dsc_adj fields (MRRS can be 4096) */
+	const_cast(unsigned int, engine->adj_block_len)=min_t(unsigned int,
+		engine->xdev->max_read_request_size /sizeof(struct xdma_desc),
+		XDMA_MAX_ADJ_BLOCK_LEN);
 	dbg_init("engine %p name %s irq_bitmask=0x%08x\n", engine, engine->name,
 		 (unsigned int) (int)engine->irq_bitmask);
 

--- a/XDMA/linux-kernel/xdma/libxdma.h
+++ b/XDMA/linux-kernel/xdma/libxdma.h
@@ -172,6 +172,12 @@
 #define DESC_MAGIC 0xAD4B0000U
 #define DESC_ADJ_SHIFT 8
 #define DESC_ADJ_MASK (0x3FU<<DESC_ADJ_SHIFT)
+/*
+ * PG195 ("Descriptors"): at most 64 descriptors in a single block of
+ * adjacent descriptors; both the descriptor Nxt_adj field and the SGDMA
+ * Descriptor Adjacent register are only 6 bits wide.
+ */
+#define XDMA_MAX_ADJ_BLOCK_LEN 64U
 
 #define C2H_WB 0x52B4U
 


### PR DESCRIPTION
`adj_block_len` was derived from MRRS alone. With MRRS = 4096 that gives 128 descriptors per block, but PG195 ('Descriptors') allows at most 64 descriptors in a single block of adjacent descriptors: the descriptor Nxt_adj field and the SGDMA Descriptor Adjacent register are only 6 bits wide. In-block Nxt_adj values up to 126 would overflow into the reserved bits [15:14] of the first descriptor dword, and the initial dsc_adj write of 127 would be silently truncated by hardware to 63, making the fetch engine's view of the block layout inconsistent with the actual descriptor chain.