### PR TITLE
Preserve non-incrementing address mode across engine re-initialisation

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1439,7 +1439,12 @@ static int engine_init_regs(struct xdma_engine *engine)
 			|XDMA_CTRL_IE_DESC_ALIGN_MISMATCH
 			|XDMA_CTRL_IE_DESC_COMPLETED
 			|XDMA_CTRL_IE_DESC_STOPPED);
-	
+
+	/* replay fixed (non-incrementing) address mode so that it survives
+	   re-initialisation through xdma_device_online() after a reset */
+	if (engine->non_incr_addr)
+		control_reg_value |= XDMA_CTRL_NON_INCR_ADDR;
+
 #ifdef XDMA_POLL_MODE
 /* if using polled mode,  enable writeback and configure its address, disable interrupts */
 	engine->poll_mode_wb.virtual_addr->completed_desc_count=0;


### PR DESCRIPTION
`engine_init_regs(`) rewrote the control register without XDMA_CTRL_NON_INCR_ADDR. After a PCI reset or XDMA_IOCONLINE the hardware silently reverted to incrementing mode while engine->non_incr_addr stayed set, so engine_addrmode_set() skipped re-arming the bit (no state change detected) and transfer validation kept applying fixed-mode alignment rules that no longer matched the hardware.