### PR TITLE
Allow only 32-bit accesses on the control device

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -44,6 +44,14 @@ static ssize_t char_ctrl_read(struct file *fp, char __user *buf, size_t count,
 	rv = xcdev_check(__func__, xcdev, 0);
 	if (rv < 0)
 		return rv;
+	/* PG195 ("PCIe to DMA Address Format"): the XDMA register space only
+	supports 32-bit requests. Partial access stays available on the user
+	(AXI4-Lite master) device, which shares these file operations. */
+	if ((xcdev->type == CHAR_CTRL) && (count != 4))
+	{
+		pr_err("Only 4-byte accesses are supported on the control device\n");
+		return -EINVAL;
+	}
 	xdev = xcdev->xdev;
 	if(xdma_device_test_offline(xdev))
 		return -EBUSY;
@@ -103,6 +111,14 @@ static ssize_t char_ctrl_write(struct file *filp, const char __user *buf,
 	rv = xcdev_check(__func__, xcdev, 0);
 	if (rv < 0)
 		return rv;
+	/* PG195 ("PCIe to DMA Address Format"): the XDMA register space only
+	supports 32-bit requests. Partial access stays available on the user
+	(AXI4-Lite master) device, which shares these file operations. */
+	if ((xcdev->type == CHAR_CTRL) && (count != 4))
+	{
+		pr_err("Only 4-byte accesses are supported on the control device\n");
+		return -EINVAL;
+	}
 	xdev = xcdev->xdev;
 	if(xdma_device_test_offline(xdev))
 		return -EBUSY;

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -37,7 +37,8 @@ static ssize_t char_ctrl_read(struct file *fp, char __user *buf, size_t count,
 	
 	if (((xcdev->type == CHAR_CTRL) && (count != 4)) || count> 4 || count==3)
 	{
-		pr_err("Unsupported access length %zu \n", count);
+		pr_err("Unsupported access length %zu to %s\n", count, 
+			xcdev->type == CHAR_CTRL? "XDMA registers" : "AXI-Lite Interface");
 		return -EINVAL;
 	}
 	
@@ -97,7 +98,8 @@ static ssize_t char_ctrl_write(struct file *filp, const char __user *buf,
 	
 	if (((xcdev->type == CHAR_CTRL) && (count != 4)) || count> 4 || count==3)
 	{
-		pr_err("Unsupported access length %zu \n", count);
+		pr_err("Unsupported access length %zu to %s\n", count, 
+			xcdev->type == CHAR_CTRL? "XDMA registers" : "AXI-Lite Interface");
 		return -EINVAL;
 	}
 	rv = xcdev_check(__func__, xcdev, 0);

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -37,8 +37,8 @@ static ssize_t char_ctrl_read(struct file *fp, char __user *buf, size_t count,
 	
 	if (((xcdev->type == CHAR_CTRL) && (count != 4)) || count> 4 || count==3)
 	{
-		pr_err("Unsupported access length %zu to %s\n", count, 
-			xcdev->type == CHAR_CTRL? "XDMA registers" : "AXI-Lite Interface");
+		pr_err("Invalid access length of %zu to %s\n", count, 
+			xcdev->type == CHAR_CTRL? "XDMA registers" : "AXI-Lite interface");
 		return -EINVAL;
 	}
 	
@@ -98,8 +98,8 @@ static ssize_t char_ctrl_write(struct file *filp, const char __user *buf,
 	
 	if (((xcdev->type == CHAR_CTRL) && (count != 4)) || count> 4 || count==3)
 	{
-		pr_err("Unsupported access length %zu to %s\n", count, 
-			xcdev->type == CHAR_CTRL? "XDMA registers" : "AXI-Lite Interface");
+		pr_err("Invalid access length of %zu to %s\n", count,
+			xcdev->type == CHAR_CTRL? "XDMA registers" : "AXI-Lite interface");
 		return -EINVAL;
 	}
 	rv = xcdev_check(__func__, xcdev, 0);
@@ -113,7 +113,6 @@ static ssize_t char_ctrl_write(struct file *filp, const char __user *buf,
 	rv=position_check(xdev->bar_size[xcdev->bar], *pos, count, count);
 	if (rv < 0)
 		return rv;
-
 	/* first address is BAR base plus file position offset */
 	reg = xdev->bar[xcdev->bar] + *pos;
 	dbg_sg("%s(%p, count=%zu, pos=%lld)\n",

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -35,7 +35,7 @@ static ssize_t char_ctrl_read(struct file *fp, char __user *buf, size_t count,
 	void __iomem *reg;
 	int rv;
 	
-	if (count> 4 || count==3)
+	if (((xcdev->type == CHAR_CTRL) && (count != 4)) || count> 4 || count==3)
 	{
 		pr_err("Unsupported access length %zu \n", count);
 		return -EINVAL;
@@ -44,14 +44,6 @@ static ssize_t char_ctrl_read(struct file *fp, char __user *buf, size_t count,
 	rv = xcdev_check(__func__, xcdev, 0);
 	if (rv < 0)
 		return rv;
-	/* PG195 ("PCIe to DMA Address Format"): the XDMA register space only
-	supports 32-bit requests. Partial access stays available on the user
-	(AXI4-Lite master) device, which shares these file operations. */
-	if ((xcdev->type == CHAR_CTRL) && (count != 4))
-	{
-		pr_err("Only 4-byte accesses are supported on the control device\n");
-		return -EINVAL;
-	}
 	xdev = xcdev->xdev;
 	if(xdma_device_test_offline(xdev))
 		return -EBUSY;
@@ -103,7 +95,7 @@ static ssize_t char_ctrl_write(struct file *filp, const char __user *buf,
 	void __iomem *reg;
 	int rv;
 	
-	if (count> 4 || count==3)
+	if (((xcdev->type == CHAR_CTRL) && (count != 4)) || count> 4 || count==3)
 	{
 		pr_err("Unsupported access length %zu \n", count);
 		return -EINVAL;
@@ -111,14 +103,7 @@ static ssize_t char_ctrl_write(struct file *filp, const char __user *buf,
 	rv = xcdev_check(__func__, xcdev, 0);
 	if (rv < 0)
 		return rv;
-	/* PG195 ("PCIe to DMA Address Format"): the XDMA register space only
-	supports 32-bit requests. Partial access stays available on the user
-	(AXI4-Lite master) device, which shares these file operations. */
-	if ((xcdev->type == CHAR_CTRL) && (count != 4))
-	{
-		pr_err("Only 4-byte accesses are supported on the control device\n");
-		return -EINVAL;
-	}
+	
 	xdev = xcdev->xdev;
 	if(xdma_device_test_offline(xdev))
 		return -EBUSY;


### PR DESCRIPTION
PG195 ('PCIe to DMA Address Format') specifies that the XDMA register bus supports 32-bit read and write requests with the two low address bits zero. The 1- and 2-byte partial access capability was introduced for the AXI4-Lite master interface, but because both devices share the same file operations it also applied to /dev/xdmaN_control, where such requests are outside the documented contract. Restrict the control device to 4-byte accesses; the user device keeps partial access.