### PR TITLE
Rename performance monitor control bits to match PG195

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.h
+++ b/XDMA/linux-kernel/xdma/libxdma.h
@@ -144,9 +144,11 @@
 #define XDMA_DESC_COMPLETED	(1U << 1)
 #define XDMA_DESC_EOP		(1U << 4)
 
-#define XDMA_PERF_RUN	(1U << 0)
+/* Performance Monitor Control (0xC0) bits, see PG195:
+   Auto = bit 0, Clear = bit 1, Run = bit 2 */
+#define XDMA_PERF_AUTO	(1U << 0)
 #define XDMA_PERF_CLEAR	(1U << 1)
-#define XDMA_PERF_AUTO	(1U << 2)
+#define XDMA_PERF_RUN	(1U << 2)
 #define XDMA_PERF_COUNT_OVERFLOW (1U<<16)
 
 #define MAGIC_ENGINE	0xEEEEEEEEU


### PR DESCRIPTION
The Performance Monitor Control register (0xC0) defines Auto as bit 0, Clear as bit 1 and Run as bit 2; the XDMA_PERF_RUN and XDMA_PERF_AUTO macros had the names swapped. No functional change: enable_perf() always writes Run and Auto together (0x5), which is the same value under either naming.