### PR TITLE
Fix interrupt setup: user IRQ mask off-by-one and MSI-X failure handling

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -920,7 +920,8 @@ static int msi_msix_capable(struct pci_dev *dev, int type)
 static void disable_msi_msix(struct xdma_dev *xdev, struct pci_dev *pdev)
 {
 	if (xdev->msix_enabled) {
-		pci_disable_msix(pdev);
+		/* counterpart of pci_alloc_irq_vectors() */
+		pci_free_irq_vectors(pdev);
 		xdev->msix_enabled = 0;
 	} else if (xdev->msi_enabled) {
 		pci_disable_msi(pdev);
@@ -944,26 +945,30 @@ static int enable_msi_msix(struct xdma_dev *xdev, struct pci_dev *pdev)
 		dbg_init("Enabling MSI-X\n");
 		/*avilable since 4.8*/
 		rv = pci_alloc_irq_vectors(pdev, req_nvec, req_nvec, PCI_IRQ_MSIX);
+		if (rv >= 0) {
+			xdev->msix_enabled = 1;
+			return 0;
+		}
+		/* fall through and try the other interrupt modes */
+		pr_warn("Couldn't enable MSI-X mode: %d. Trying MSI/legacy.\n",
+			rv);
+	}
 
-		if (rv < 0)
-			dbg_init("Couldn't enable MSI-X mode: %d\n", rv);
-
-		xdev->msix_enabled = 1;
-
-	} else if ((interrupt_mode == 1 || !interrupt_mode) &&
+	if ((interrupt_mode == 1 || !interrupt_mode) &&
 		   msi_msix_capable(pdev, PCI_CAP_ID_MSI)) {
 		/* enable message signalled interrupts */
 		dbg_init("pci_enable_msi()\n");
 		rv = pci_enable_msi(pdev);
-		if (rv < 0)
-			dbg_init("Couldn't enable MSI mode: %d\n", rv);
-		xdev->msi_enabled = 1;
-
-	} else {
-		dbg_init("MSI/MSI-X not detected - using legacy interrupts\n");
+		if (rv == 0) {
+			xdev->msi_enabled = 1;
+			return 0;
+		}
+		pr_warn("Couldn't enable MSI mode: %d. Falling back to legacy interrupts.\n",
+			rv);
 	}
 
-	return rv;
+	dbg_init("MSI/MSI-X not enabled - using legacy interrupts\n");
+	return 0;
 }
 
 static void pci_check_intr_pend(struct pci_dev *pdev)

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -128,7 +128,8 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 		pr_warn("NO engine found!\n");
 
 	if (xpdev->user_max) {
-		u32 mask = (1 << (xpdev->user_max + 1)) - 1;
+		/* one enable bit per user interrupt, [user_max-1:0] */
+		u32 mask = (1 << xpdev->user_max) - 1;
 
 		rv = xdma_user_isr_enable(hndl, mask);
 		if (rv)


### PR DESCRIPTION
- probe_one() enabled (user_max + 1) user interrupt sources; the IRQ Block User Interrupt Enable Mask is defined for [NUM_USR_INT-1:0] only. With user_max below the hardware's NUM_USR_INT the extra source would fire with no vector programmed (defaulting to vector 0, which belongs to engine H2C0 in MSI-X mode) and no handler attached.

- enable_msi_msix() set msix_enabled/msi_enabled even when vector allocation failed and returned that error, aborting the whole probe instead of falling back to a lower-precedence mode. Only set the flags on success and fall back MSI-X -> MSI -> legacy (matching the interrupt precedence in PG195 3.4.7). Also release MSI-X vectors with `pci_free_irq_vectors()`, the proper counterpart of `pci_alloc_irq_vectors()` (`disable_msi_msix()` used pci_disable_msix()).