### PR TITLE
Fix descriptor length accounting across adjacent blocks

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -2013,11 +2013,13 @@ static long xdma_wait_for_transfer(struct xdma_engine *engine)
 static ssize_t calculate_completed_length(const struct xdma_engine *engine, u32 num_descriptors)
 {
 	ssize_t completed_length=0;
-	unsigned int block=0, desc=0;
-	for(; num_descriptors; ++block)
-		for(; (desc < engine->transfer.adj_desc_blocks[block].length) && num_descriptors; --num_descriptors, ++desc)		
+	unsigned int block=0;
+	for(; (block < engine->transfer.num_adj_blocks) && num_descriptors; ++block)
+	{
+		unsigned int desc=0;
+		for(; (desc < engine->transfer.adj_desc_blocks[block].length) && num_descriptors; --num_descriptors, ++desc)
 			completed_length += engine->transfer.adj_desc_blocks[block].virtual_addr[desc].bytes;
-		
+	}
 	return completed_length;
 
 }


### PR DESCRIPTION
`calculate_completed_length()` shared a single desc index across all adjacent descriptor blocks and left the outer loop unbounded: after the first block desc was never reset, so the inner loop stopped counting and num_descriptors was never decremented. The outer loop then advanced block past num_adj_blocks and dereferenced out-of-bounds adjacent-block records; it only produced a correct result for single-block transfers.

Bound the outer loop by num_adj_blocks and reset desc for each block. This runs on the partial-completion path (short read, error or timeout with partial progress), so the bug affected multi-block transfers that did not complete in full.