### PR TITLE
Fix PCIe domain value reported by the info ioctl

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -172,7 +172,7 @@ static long version_ioctl(struct xdma_cdev *xcdev, void __user *arg)
 	obj.subsystem_device = xdev->pdev->subsystem_device;
 	obj.feature_id = xdev->feature_id;
 	obj.driver_version = DRV_MOD_VERSION_NUMBER;
-	obj.domain = xdev->pdev->slot->number;
+	obj.domain = pci_domain_nr(xdev->pdev->bus);
 	obj.bus = xdev->pdev->bus->number;
 	obj.dev = PCI_SLOT(xdev->pdev->devfn);
 	obj.func = PCI_FUNC(xdev->pdev->devfn);


### PR DESCRIPTION
fa58818 ("Merge PR190 'fixed PCIe domain and bus values in info ioctl'") set obj.domain in `version_ioctl()` from `pdev->slot>number`. That field is the physical slot number, not the PCI domain, and `pdev->slot` is NULL unless the device is bound to a registered PCI slot, so XDMA_IOCTL_INFO reported a wrong domain or dereferenced a NULL pointer. Use `pci_domain_nr(pdev>bus)`, the correct source for the domain number. 